### PR TITLE
Fix Deprecated notices when there is no thumbnail

### DIFF
--- a/build/blocks/social-sharing-link.php
+++ b/build/blocks/social-sharing-link.php
@@ -128,7 +128,7 @@ function block_outermost_social_sharing_link_services( $service = '', $field = '
 
 	$permalink = rawurlencode( get_the_permalink() );
 	$title     = rawurlencode( get_the_title() );
-	$image     = rawurlencode( esc_url( $thumbnail ) );
+	$image     = empty($thumbnail) ? '' : rawurlencode( esc_url( $thumbnail ) );
 	$separator = '%20&mdash;%20';
 
 	$services_data = array(

--- a/build/blocks/social-sharing-link.php
+++ b/build/blocks/social-sharing-link.php
@@ -128,7 +128,7 @@ function block_outermost_social_sharing_link_services( $service = '', $field = '
 
 	$permalink = rawurlencode( get_the_permalink() );
 	$title     = rawurlencode( get_the_title() );
-	$image     = empty($thumbnail) ? '' : rawurlencode( esc_url( $thumbnail ) );
+	$image     = empty( $thumbnail ) ? '' : rawurlencode( esc_url( $thumbnail ) );
 	$separator = '%20&mdash;%20';
 
 	$services_data = array(


### PR DESCRIPTION
When the block added to the page that doesn't have a thumbnail there are numerous PHP Deprecated notices, coming from: 	ltrim(): Passing null to parameter #1 ($string) of type string is deprecated. This can be fixed by checking thumbnail value for not being empty.
![pcQJ02x](https://user-images.githubusercontent.com/5646904/234095046-25f7a482-fb75-447d-8b79-2874e4b9d26a.png)
