### PR TITLE
Fix hyphen being rendered as &#8211; in the post title on Social Media.

### DIFF
--- a/build/social-sharing-link/utils.php
+++ b/build/social-sharing-link/utils.php
@@ -113,7 +113,7 @@ function get_link_services( $share_custom_link, $block ) {
 	}
 
 	$separator       = '%20&mdash;%20';
-	$title = str_replace('&#8211;', '-', $title); // Replace &#8211; with -. Prevents the title of the post to contain &#8211; instead of the proper - on social media. Tested on Twitter and Reddit.
+	$title           = str_replace( [ '&#8211;', '&ndash;', '&#8212;', '&mdash;' ], [ '–', '–', '—', '—' ], $string ); // Replace encoded en and em dashes.
 	$title_separator = $title ? $title . $separator : '';
 
 	$and_title_title      = $title ? '&title=' . $title : '';

--- a/build/social-sharing-link/utils.php
+++ b/build/social-sharing-link/utils.php
@@ -113,6 +113,7 @@ function get_link_services( $share_custom_link, $block ) {
 	}
 
 	$separator       = '%20&mdash;%20';
+	$title = str_replace('&#8211;', '-', $title); // Replace &#8211; with -. Prevents the title of the post to contain &#8211; instead of the proper - on social media. Tested on Twitter and Reddit.
 	$title_separator = $title ? $title . $separator : '';
 
 	$and_title_title      = $title ? '&title=' . $title : '';


### PR DESCRIPTION
Replace `&#8211;` with -. Prevents the title of the post to contain `&#8211;` instead of the proper - on social media. Tested on Twitter and Reddit.